### PR TITLE
Feature: terminate specific Java backend headless instances by port 

### DIFF
--- a/src/mmpycorex/_version.py
+++ b/src/mmpycorex/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 3, 15)
+version_info = (0, 3, 16)
 __version__ = ".".join(map(str, version_info))

--- a/src/mmpycorex/install.py
+++ b/src/mmpycorex/install.py
@@ -68,14 +68,24 @@ def find_existing_mm_install():
         The path to the installed Micro-Manager directory, or None if not found
     """
     platform = _get_platform()
-    if platform == 'Windows':
-        if os.path.isdir(r'C:\Program Files\Micro-Manager'):
-            return r'C:\Program Files\Micro-Manager'
-    elif platform == 'Mac':
-        if os.path.isdir(str(os.path.expanduser('~')) + '/Micro-Manager'):
-            return str(os.path.expanduser('~')) + '/Micro-Manager'
-    else:
+
+    dir_names = ['Micro-Manager', 'Micro-Manager-2.0']
+
+    paths = {
+        'Windows': os.environ.get('PROGRAMFILES', r'C:\Program Files'),
+        'Mac': os.path.expanduser('~'),
+    }
+
+    if platform not in paths:
         raise ValueError(f"Unsupported OS: {platform}")
+    
+
+    for dir_name in dir_names:
+        path = os.path.join(paths[platform], dir_name)
+        if os.path.isdir(path):
+            return path
+
+    raise FileNotFoundError('Micro-Manager not found in the default installation path.')
 
 def get_default_install_location():
     """

--- a/src/mmpycorex/launcher.py
+++ b/src/mmpycorex/launcher.py
@@ -217,7 +217,7 @@ def create_core_instance(
         mm_app_path = get_default_install_location()
 
     # if config file is not an absolute path, assume it is relative to the mm_app_path
-    if not os.path.isabs(config_file):
+    if config_file is not None and not os.path.isabs(config_file):
         config_file = os.path.join(mm_app_path, config_file)
 
     if python_backend:

--- a/src/mmpycorex/launcher.py
+++ b/src/mmpycorex/launcher.py
@@ -6,7 +6,7 @@ import threading
 import types
 import os
 
-from .install import get_default_install_location
+from .install import find_existing_mm_install
 from pymmcore import CMMCore
 import pymmcore
 from pyjavaz import DEFAULT_BRIDGE_PORT, server_terminated
@@ -214,7 +214,7 @@ def create_core_instance(
         Print debug messages
     """
     if mm_app_path == 'auto':
-        mm_app_path = get_default_install_location()
+        mm_app_path = find_existing_mm_install()
 
     # if config file is not an absolute path, assume it is relative to the mm_app_path
     if config_file is not None and not os.path.isabs(config_file):
@@ -234,7 +234,7 @@ def create_core_instance(
         # attach TaggedImage class
         mmc.TaggedImage = TaggedImage
     else:
-        if is_java_port_allocated():
+        if is_java_port_allocated(port):
             raise Exception(f'Port {port} already in use')
 
         classpath = mm_app_path + '/plugins/Micro-Manager/*'


### PR DESCRIPTION
### Terminate specific Java backend

```Python
def terminate_java_instances(debug=False, port: int = None):
    """
    Terminate headless instances of Micro-Manager core started with the Java backend.

    Parameters
    ----------
    debug : bool
        Print debug messages
    port : int
        Port of the server to terminate. If None, all servers will be terminated
    """
    if not is_java_active():
        logger.debug('No Java instances to stop')
        return

    for key in active_java_ports():
        if port and port != key:
            continue

        process = _JAVA_HEADLESS_SUBPROCESSES[key]
        if debug:
            logger.debug(f'Stopping headless process with pid {process.pid}')
        process.terminate()
        server_terminated(key)
        if debug:
            logger.debug(f'Waiting for process with pid {process.pid} to terminate')
        process.wait()  # wait for process to terminate
        if debug:
            logger.debug(f'Process with pid {process.pid} terminated')
        del _JAVA_HEADLESS_SUBPROCESSES[key]
```

Terminate specific Java backend processes by tracking subprocesses using port numbers. This helps manage multiple headless instances.

```Python
_JAVA_HEADLESS_SUBPROCESSES : dict[int, subprocess.Popen] = {}
```

If the `create_core_instance` function is called using a port that is already in use, an exception will be raised.
```Python
if is_java_port_allocated():
    raise Exception(f'Port {port} already in use')
```

Also, I have split the `terminate_core_instances` function into two
functions:
- `terminate_java_instances`
- `terminate_pymmcore_instances`

Added convenience functions: `is_java_active`, `is_java_port_allocated` and `active_java_ports`. 